### PR TITLE
Add RandomizeRotation to IslandViewModel

### DIFF
--- a/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/FixedIslandViewModel.cs
@@ -16,6 +16,8 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         public override int ThumbnailRotation => _thumbnailRotation ?? 0;
         private int? _thumbnailRotation;
 
+        public override bool RandomizeRotation => _fixedIsland.RandomizeRotation;
+
 
         public FixedIslandViewModel(Session session, FixedIslandElement fixedIsland) 
             : base(session, fixedIsland)

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandControl.xaml
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandControl.xaml
@@ -44,7 +44,7 @@
             <Polygon Stroke="DarkGoldenrod"
                      Fill="Gold"
                      Points="0,0 40,0 0,40"
-                     Visibility="{Binding Island.RandomizeRotation, Converter={StaticResource VisibleOnFalse}, FallbackValue=Hidden}"/>
+                     Visibility="{Binding RandomizeRotation, Converter={StaticResource VisibleOnFalse}, FallbackValue=Hidden}"/>
         </Canvas>
 
         <!-- Label -->

--- a/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/IslandViewModel.cs
@@ -64,6 +64,8 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
 
         public virtual int ThumbnailRotation { get; }
 
+        public virtual bool RandomizeRotation => true;
+
 
         public IslandViewModel(Session session, IslandElement island)
             : base(island)
@@ -74,7 +76,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
             UpdateBackground();
 
             PropertyChanged += This_PropertyChanged;
-            Island.PropertyChanged += RandomIsland_PropertyChanged;
+            Island.PropertyChanged += Island_PropertyChanged;
         }
 
 
@@ -84,10 +86,12 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
                 UpdateBackground();
         }
 
-        private void RandomIsland_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        private void Island_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(IslandElement.IslandType))
                 UpdateBackground();
+            else if (e.PropertyName == nameof(FixedIslandElement.RandomizeRotation))
+                UpdateRotation();
         }
 
         private void UpdateBackground()
@@ -102,6 +106,11 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
                 BorderBrush = BorderBrushes[Island.IslandType.Name];
                 BackgroundBrush = BackgroundBrushes[Island.IslandType.Name];
             }
+        }
+
+        private void UpdateRotation()
+        {
+            OnPropertyChanged(nameof(RandomizeRotation));
         }
 
         public override void OnDragged(Vector2 newPosition)


### PR DESCRIPTION
Adds the RandomizeRotation bool to the IslandViewModel, so the Binding does not pull that information from the underlying Island anymore, since RandomizeRotation only exists for FixedIslands there as Random Islands always have randomized rotation.
This avoids warnings for Binding Errors caused by having to use a Fallback.