### PR TITLE
Make Slot Map View Lines update on Filter change

### DIFF
--- a/AnnoMapEditor/UI/Overlays/SelectSlots/SelectSlotsOverlay.xaml.cs
+++ b/AnnoMapEditor/UI/Overlays/SelectSlots/SelectSlotsOverlay.xaml.cs
@@ -77,9 +77,6 @@ namespace AnnoMapEditor.UI.Overlays.SelectSlots
 
         private void SelectSlotsViewModel_FilterChanged(object? sender, SelectSlotsViewModel.FilteredItemsChangedEventArgs<SlotAssignmentViewModel> e)
         {
-            SlotSelectionsLeft.UpdateLayout();
-            SlotSelectionsRight.UpdateLayout();
-
             if (e.RemovedItems != null)
             {
                 foreach (SlotAssignmentViewModel slotAssignment in e.RemovedItems)

--- a/AnnoMapEditor/UI/Overlays/SelectSlots/SelectSlotsOverlay.xaml.cs
+++ b/AnnoMapEditor/UI/Overlays/SelectSlots/SelectSlotsOverlay.xaml.cs
@@ -60,14 +60,14 @@ namespace AnnoMapEditor.UI.Overlays.SelectSlots
         {
             if (e.OldValue is SelectSlotsViewModel oldViewModel)
             {
-                oldViewModel.SlotAssignmentViewModels.CollectionChanged -= SlotAssignmentViewModels_CollectionChanged;
+                oldViewModel.FilterModified -= SelectSlotsViewModel_FilterChanged;
                 foreach (SlotAssignmentViewModel slotAssignment in oldViewModel.SlotAssignmentViewModels)
                     slotAssignment.PropertyChanged -= SlotAssginment_PropertyChanged;
             }
 
             if (e.NewValue is SelectSlotsViewModel newViewModel)
             {
-                newViewModel.SlotAssignmentViewModels.CollectionChanged += SlotAssignmentViewModels_CollectionChanged;
+                newViewModel.FilterModified += SelectSlotsViewModel_FilterChanged;
                 foreach (SlotAssignmentViewModel slotAssignment in newViewModel.SlotAssignmentViewModels)
                     slotAssignment.PropertyChanged += SlotAssginment_PropertyChanged;
             }
@@ -75,11 +75,14 @@ namespace AnnoMapEditor.UI.Overlays.SelectSlots
             UpdatePointers();
         }
 
-        private void SlotAssignmentViewModels_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        private void SelectSlotsViewModel_FilterChanged(object? sender, SelectSlotsViewModel.FilteredItemsChangedEventArgs<SlotAssignmentViewModel> e)
         {
-            if (e.OldItems != null)
+            SlotSelectionsLeft.UpdateLayout();
+            SlotSelectionsRight.UpdateLayout();
+
+            if (e.RemovedItems != null)
             {
-                foreach (SlotAssignmentViewModel slotAssignment in e.OldItems)
+                foreach (SlotAssignmentViewModel slotAssignment in e.RemovedItems)
                 {
                     slotAssignment.PropertyChanged -= SlotAssginment_PropertyChanged;
 
@@ -90,11 +93,20 @@ namespace AnnoMapEditor.UI.Overlays.SelectSlots
                 }
             }
 
-            if (e.NewItems != null)
+            if (e.AddedItems != null)
             {
-                foreach (SlotAssignmentViewModel slotAssignment in e.NewItems)
+                foreach (SlotAssignmentViewModel slotAssignment in e.AddedItems)
                 {
                     slotAssignment.PropertyChanged += SlotAssginment_PropertyChanged;
+                    UpdatePointer(slotAssignment);
+                }
+            }
+
+            //Update the lines for the unchanged items as well, since the combobox positions will have changed
+            if(e.UnchangedItems != null)
+            {
+                foreach (SlotAssignmentViewModel slotAssignment in e.UnchangedItems)
+                {
                     UpdatePointer(slotAssignment);
                 }
             }


### PR DESCRIPTION
Use a separate event to trigger the rebuild of the lines, after the display collection changes have been handled by the bindings.