### PR TITLE
Small code cleanup

### DIFF
--- a/AnnoMapEditor/DataArchives/Assets/Models/MinimapSceneAsset.cs
+++ b/AnnoMapEditor/DataArchives/Assets/Models/MinimapSceneAsset.cs
@@ -11,7 +11,7 @@ namespace AnnoMapEditor.DataArchives.Assets.Models
     [AssetTemplate("MinimapScene")]
     public class MinimapSceneAsset : StandardAsset
     {
-        public const long GUID = 500204;
+        public new const long GUID = 500204;
 
 
         public List<long> FertilityOrderGuids { get; init; }

--- a/AnnoMapEditor/DataArchives/Assets/Models/SlotAsset.cs
+++ b/AnnoMapEditor/DataArchives/Assets/Models/SlotAsset.cs
@@ -31,9 +31,12 @@ namespace AnnoMapEditor.DataArchives.Assets.Models
         public IEnumerable<Region> AssociatedRegions { get; init; }
 
 
-        public SlotAsset()
+        public SlotAsset() : base()
         {
-
+            DisplayName = "";
+            ReplacementGuids = Enumerable.Empty<long>();
+            ReplacementSlotAssets = Enumerable.Empty<SlotAsset>();
+            AssociatedRegions = Enumerable.Empty<Region>();
         }
 
 
@@ -75,6 +78,8 @@ namespace AnnoMapEditor.DataArchives.Assets.Models
                 .Select(id => Region.FromRegionId(id))
                 .ToArray()
                 ?? Array.Empty<Region>();
+
+            ReplacementSlotAssets = Enumerable.Empty<SlotAsset>();
         }
     }
 }

--- a/AnnoMapEditor/DataArchives/Assets/Models/StandardAsset.cs
+++ b/AnnoMapEditor/DataArchives/Assets/Models/StandardAsset.cs
@@ -6,7 +6,7 @@ using System.Xml.Linq;
 
 namespace AnnoMapEditor.DataArchives.Assets.Models
 {
-    public class StandardAsset : ObservableBase
+    public abstract class StandardAsset : ObservableBase
     {
         private static readonly string TemplateName = "Standard";
 

--- a/AnnoMapEditor/DataArchives/Assets/Repositories/FixedIslandRepository.cs
+++ b/AnnoMapEditor/DataArchives/Assets/Repositories/FixedIslandRepository.cs
@@ -37,7 +37,7 @@ namespace AnnoMapEditor.DataArchives.Assets.Repositories
         {
             _logger.LogInformation($"Begin loading fixed islands.");
 
-            foreach (string mapFilePath in _dataArchive.Find("**.a7m"))
+            foreach (string mapFilePath in _dataArchive.Find("*.a7m"))
             {
                 // thumbnail
                 string thumbnailPath = Path.Combine(

--- a/AnnoMapEditor/MapTemplates/Enums/Region.cs
+++ b/AnnoMapEditor/MapTemplates/Enums/Region.cs
@@ -98,11 +98,11 @@ namespace AnnoMapEditor.MapTemplates.Enums
 
         public static Region DetectFromPath(string filePath)
         {
-            if (filePath.Contains("colony01"))
+            if (filePath.Contains("colony01") || filePath.Contains("ggj") || filePath.Contains("scenario03"))
                 return NewWorld;
             else if (filePath.Contains("dlc03") || filePath.Contains("colony_03"))
                 return Arctic;
-            else if (filePath.Contains("dlc06") || filePath.Contains("colony02"))
+            else if (filePath.Contains("dlc06") || filePath.Contains("colony02") || filePath.Contains("scenario02"))
                 return Enbesa;
             return Moderate;
         }

--- a/AnnoMapEditor/UI/Controls/Fertilities/FertilitiesViewModel.cs
+++ b/AnnoMapEditor/UI/Controls/Fertilities/FertilitiesViewModel.cs
@@ -24,6 +24,9 @@ namespace AnnoMapEditor.UI.Controls.Fertilities
             FixedIsland = fixedIsland;
             Region = region;
 
+            if(fixedIsland.RandomizeFertilities == false)
+                SortFertilities();
+
             fixedIsland.Fertilities.CollectionChanged += SortFertilities;
         }
 

--- a/AnnoMapEditor/UI/Controls/MapTemplates/StartingSpotControl.xaml.cs
+++ b/AnnoMapEditor/UI/Controls/MapTemplates/StartingSpotControl.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using System.Windows.Controls;
 
 namespace AnnoMapEditor.UI.Controls.MapTemplates
 {
@@ -14,6 +15,7 @@ namespace AnnoMapEditor.UI.Controls.MapTemplates
         public StartingSpotControl()
         {
             InitializeComponent();
+            Panel.SetZIndex(this, 1);
         }
     }
 }


### PR DESCRIPTION
The proposed code cleanup changes I posted in the PR on the main repo.
- Make StandardAsset abstract
- Make SlotAsset constructors initialize collections as empty instead of null

Additional Changes:
- Make MinimapSceneAsset properly overwrite the StandardAsset GUID Property with the `new` keyword
- Starting Spot Controls dont get hidden by islands
- Fertility Control now shows the configured fertilities when clicking on an island correctly
